### PR TITLE
docs: reference image-converter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is a minimal Next.js + TypeScript + Tailwind scaffold with two tools ready:
 
 - **/qr** — QR / Wi‑Fi QR generator (PNG/SVG downloads)
-- **/heic-to-jpg** — HEIC → JPG converter (client‑side with `heic2any`)
+- **/image-converter** — HEIC → JPG converter (client‑side with `heic2any`)
 
 Ads are gated behind a simple consent banner. Replace the AdSense client and slot IDs before launch.
 


### PR DESCRIPTION
## Summary
- update tool path in README to `/image-converter`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6893f6bbaf0c8329ba1393b7bd40411a