### PR TITLE
Close ImageBitmap after encoding in ImageConverter

### DIFF
--- a/components/ImageConverter.tsx
+++ b/components/ImageConverter.tsx
@@ -56,12 +56,15 @@ export default function ImageConverter({
         }
 
         const bitmap = await decodeImage(srcBlob);
-        const blob = await encodeBitmap(bitmap, fmt, quality, bg);
-
-        const targetExt = fmt === 'image/jpeg' ? 'jpg' : fmt === 'image/png' ? 'png' : 'webp';
-        const base = f.name.replace(/\.[^.]+$/, '');
-        const url = URL.createObjectURL(blob);
-        setResults((prev) => [...prev, { name: `${base}.${targetExt}`, url }]);
+        try {
+          const blob = await encodeBitmap(bitmap, fmt, quality, bg);
+          const targetExt = fmt === 'image/jpeg' ? 'jpg' : fmt === 'image/png' ? 'png' : 'webp';
+          const base = f.name.replace(/\.[^.]+$/, '');
+          const url = URL.createObjectURL(blob);
+          setResults((prev) => [...prev, { name: `${base}.${targetExt}`, url }]);
+        } finally {
+          bitmap.close();
+        }
       } catch (e: any) {
         addLog(`❌ ${f.name}: ${e?.message || e}`);
         console.error(e);


### PR DESCRIPTION
## Summary
- release ImageBitmap resources after encoding to prevent memory leaks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_6893f6b61b048329a0f4965e2b5563a6