### PR TITLE
fix home page tagline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,9 @@ export default function Page() {
       {/* Intro card, centered */}
       <section className="card mx-auto max-w-screen-lg">
         <h1 className="text-2xl font-semibold">🛠️ PocketTool</h1>
-        <p className="text-neutral-300 mt-1">A Swiss-army knife of fast, private web tools. Everything runs in your browser — we never upload your files.</p>
+        <p className="text-neutral-300 mt-1">
+          A Swiss-army knife of fast, private web tools. Everything runs in your browser — we never upload your files.
+        </p>
       </section>
 
       {/* Ad slot */}


### PR DESCRIPTION
## Summary
- ensure home page tagline uses a single-line string so "browser" is intact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Would prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6893f6a88180832982086ed81c2adb24