### PR TITLE
chore: manage ffmpeg core assets via script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .env*
 *.log
 dist
+public/ffmpeg/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-      "test": "jest"
+    "test": "jest",
+    "postinstall": "node scripts/copy-ffmpeg.js"
   },
   "dependencies": {
     "clsx": "^2.1.0",

--- a/scripts/copy-ffmpeg.js
+++ b/scripts/copy-ffmpeg.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(process.cwd(), 'node_modules', '@ffmpeg', 'core', 'dist');
+const destDir = path.join(process.cwd(), 'public', 'ffmpeg');
+
+if (!fs.existsSync(srcDir)) {
+  console.warn(`@ffmpeg/core not found at ${srcDir}. Skipping copy.`);
+  process.exit(0);
+}
+
+fs.mkdirSync(destDir, { recursive: true });
+for (const file of fs.readdirSync(srcDir)) {
+  fs.copyFileSync(path.join(srcDir, file), path.join(destDir, file));
+}
+
+console.log('Copied @ffmpeg/core files to public/ffmpeg');
+


### PR DESCRIPTION
## Summary
- avoid versioning ffmpeg core files by gitignoring `public/ffmpeg/`
- add postinstall copy script for `@ffmpeg/core` assets

## Testing
- `node scripts/copy-ffmpeg.js`
- `npm test -- --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689400791e788329bfe5f818df48c30a