### PR TITLE
Fix ffmpeg path and improve MP4 to GIF UX

### DIFF
--- a/app/video-to-gif/page.tsx
+++ b/app/video-to-gif/page.tsx
@@ -60,8 +60,16 @@ export default function VideoToGifPage() {
             setVideo(e.target.files?.[0] || null)
             setGifUrl('')
           }}
-          className="mb-4"
+          className="mb-2"
         />
+
+        <p className="text-sm text-neutral-500 mb-4">
+          {!ready
+            ? 'Loading FFmpeg…'
+            : video
+            ? `Selected: ${video.name} (${(video.size / 1024 / 1024).toFixed(1)} MB)`
+            : 'No file selected'}
+        </p>
 
         <div className="flex flex-wrap gap-4 mb-4">
           <label className="flex flex-col text-sm">
@@ -97,7 +105,13 @@ export default function VideoToGifPage() {
         </div>
 
         <button onClick={convert} disabled={!ready || !video || busy} className="btn w-full">
-          {busy ? 'Converting…' : 'Convert to GIF'}
+          {busy
+            ? 'Converting…'
+            : !ready
+            ? 'Loading FFmpeg…'
+            : !video
+            ? 'Select an MP4 file'
+            : 'Convert to GIF'}
         </button>
 
         {gifUrl && (

--- a/scripts/copy-ffmpeg.js
+++ b/scripts/copy-ffmpeg.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const srcDir = path.join(process.cwd(), 'node_modules', '@ffmpeg', 'core', 'dist', 'umd');
+const baseDir = path.join(process.cwd(), 'node_modules', '@ffmpeg', 'core', 'dist');
+const umdDir = path.join(baseDir, 'umd');
+const srcDir = fs.existsSync(umdDir) ? umdDir : baseDir;
 const destDir = path.join(process.cwd(), 'public', 'ffmpeg');
 
 if (!fs.existsSync(srcDir)) {
@@ -23,4 +25,4 @@ for (const file of expectedFiles) {
   }
 }
 
-console.log('Copied @ffmpeg/core UMD files to public/ffmpeg');
+console.log('Copied @ffmpeg/core files to public/ffmpeg');


### PR DESCRIPTION
## Summary
- copy ffmpeg-core assets from actual dist folder
- show video selection and loading status in MP4→GIF UI

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894edec04d88329b6eaa4a4382e8c3a