### PR TITLE
Enhance SEO metadata and structured data

### DIFF
--- a/app/cookies/Client.tsx
+++ b/app/cookies/Client.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export default function ResetConsent() {
+  return (
+    <button
+      className="px-3 py-2 rounded bg-brand"
+      onClick={() => {
+        localStorage.removeItem('pt_consent');
+        location.reload();
+      }}
+    >
+      Reopen consent
+    </button>
+  );
+}

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -1,9 +1,21 @@
+import type { Metadata } from "next";
+import ResetConsent from "./Client";
 
-'use client'
-export default function Cookies(){
-  return <div className="prose prose-invert max-w-none">
-    <h1>Cookies</h1>
-    <p>To fund free tools, we use advertising cookies only after you consent. You can revoke consent below.</p>
-    <button className="px-3 py-2 rounded bg-brand" onClick={()=>{ localStorage.removeItem('pt_consent'); location.reload() }}>Reopen consent</button>
-  </div>
+export const metadata: Metadata = {
+  title: "Cookie Settings — Utilixy",
+  description:
+    "Manage or revoke your consent for advertising cookies on Utilixy.",
+};
+
+export default function Cookies() {
+  return (
+    <div className="prose prose-invert max-w-none">
+      <h1>Cookies</h1>
+      <p>
+        To fund free tools, we use advertising cookies only after you consent.
+        You can revoke consent below.
+      </p>
+      <ResetConsent />
+    </div>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,17 @@ export const metadata: Metadata = {
     "QR & Wi-Fi codes, image and PDF tools, formatters and random generators — all running locally in your browser.",
   manifest: "/manifest.json",
   themeColor: "#3B82F6",
+  metadataBase: new URL("https://utilixy.com"),
+  alternates: { canonical: "/" },
+  robots: { index: true, follow: true },
+  keywords: [
+    "PDF tools",
+    "QR code generator",
+    "image converter",
+    "JSON formatter",
+    "Base64 encoder",
+    "random generator",
+  ],
   openGraph: {
     title: "Utilixy — Quick, private web tools",
     description:
@@ -48,6 +59,15 @@ const themeInitScript = `
   } catch (e) {}
 `;
 
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Utilixy",
+  url: "https://utilixy.com",
+  description:
+    "Quick, private web tools that run locally in your browser.",
+};
+
 
 export default function RootLayout({
   children,
@@ -70,6 +90,10 @@ export default function RootLayout({
         <link
           href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
           rel="stylesheet"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       </head>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,19 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "PDF Studio & Web Tools — Utilixy",
+  description:
+    "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local and private.",
+  keywords: [
+    "PDF Studio",
+    "web tools",
+    "QR code generator",
+    "image converter",
+    "JSON formatter",
+    "random generators",
+  ],
+};
 
 const tools = [
   { href: "/pdf", title: "PDF Studio", desc: "Reorder, rotate, merge, split, numbers, watermark, extract, redact — locally." },

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,8 +1,23 @@
+import type { Metadata } from "next";
 
-export default function Privacy(){
-  return <div className="prose prose-invert max-w-none">
-    <h1>Privacy</h1>
-    <p>Utilixy runs most processing in your browser. Files you use in tools like HEIC→JPG or QR generator are not uploaded to our servers.</p>
-    <p>We show a small number of ads to keep tools free. Ads only load after you accept cookies in the consent banner.</p>
-  </div>
+export const metadata: Metadata = {
+  title: "Privacy Policy — Utilixy",
+  description:
+    "Understand how Utilixy handles data, cookies, and local processing for web tools.",
+};
+
+export default function Privacy() {
+  return (
+    <div className="prose prose-invert max-w-none">
+      <h1>Privacy</h1>
+      <p>
+        Utilixy runs most processing in your browser. Files you use in tools like
+        HEIC→JPG or QR generator are not uploaded to our servers.
+      </p>
+      <p>
+        We show a small number of ads to keep tools free. Ads only load after you
+        accept cookies in the consent banner.
+      </p>
+    </div>
+  );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,7 +1,19 @@
+import type { Metadata } from "next";
 
-export default function Terms(){
-  return <div className="prose prose-invert max-w-none">
-    <h1>Terms</h1>
-    <p>Utilixy is provided as-is, without warranties. Use responsibly and ensure you have rights to the files you process.</p>
-  </div>
+export const metadata: Metadata = {
+  title: "Terms of Service — Utilixy",
+  description:
+    "Review the usage terms for Utilixy's local-first web tools and services.",
+};
+
+export default function Terms() {
+  return (
+    <div className="prose prose-invert max-w-none">
+      <h1>Terms</h1>
+      <p>
+        Utilixy is provided as-is, without warranties. Use responsibly and
+        ensure you have rights to the files you process.
+      </p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- expand site-wide metadata with canonical URL, robots directives, keywords and JSON-LD structured data
- add specific metadata for home, cookies, privacy and terms pages
- refactor cookie settings page to support server metadata with a client-only reset button

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9247b8c4832988cfb0cb60c0e27c