### PR TITLE
feat: enhance SEO with sitemap and robots

### DIFF
--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -6,12 +6,23 @@ export const metadata: Metadata = {
   title: 'Text Difference Checker — Utilixy',
   description:
     'Compare two blocks of text and highlight additions, deletions, and unchanged parts. Everything runs in your browser.',
+  alternates: { canonical: '/diff' },
+  robots: { index: true, follow: true },
+  keywords: [
+    'text diff',
+    'compare text online',
+    'diff checker',
+    'text difference tool',
+    'inline diff',
+    'side by side diff',
+  ],
   openGraph: {
     title: 'Text Difference Checker — Utilixy',
     description:
       'Compare two blocks of text and highlight additions, deletions, and unchanged parts. Everything runs in your browser.',
     url: '/diff',
     siteName: 'Utilixy',
+    images: [{ url: '/icons/icon-512.png', width: 512, height: 512 }],
     type: 'website',
   },
   twitter: {
@@ -19,6 +30,7 @@ export const metadata: Metadata = {
     title: 'Text Difference Checker — Utilixy',
     description:
       'Compare two blocks of text and highlight additions, deletions, and unchanged parts. Everything runs in your browser.',
+    images: ['/icons/icon-512.png'],
   },
 };
 

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -1,10 +1,38 @@
 import ToolLayout from "@/components/ToolLayout";
+import type { Metadata } from "next";
 import Client from "./Client";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Wi-Fi QR Code Generator — Utilixy",
   description:
     "Create Wi-Fi QR codes (WPA/WEP/Open) and standard QR codes for text, email or SMS. Export PNG/SVG. Everything runs locally.",
+  alternates: { canonical: "/qr" },
+  robots: { index: true, follow: true },
+  keywords: [
+    "wifi qr code",
+    "wi-fi qr code generator",
+    "network qr code",
+    "qr code maker",
+    "free qr generator",
+    "wifi password qr",
+    "wifi connect qr",
+  ],
+  openGraph: {
+    title: "Wi-Fi QR Code Generator — Utilixy",
+    description:
+      "Create Wi-Fi QR codes and standard QR codes for text, email or SMS. Export PNG/SVG. Everything runs locally.",
+    url: "/qr",
+    siteName: "Utilixy",
+    images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Wi-Fi QR Code Generator — Utilixy",
+    description:
+      "Create Wi-Fi QR codes and standard QR codes for text, email or SMS. Export PNG/SVG. Everything runs locally.",
+    images: ["/icons/icon-512.png"],
+  },
 };
 
 export default function Page() {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: 'https://utilixy.com/sitemap.xml',
+    host: 'https://utilixy.com',
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = 'https://utilixy.com';
+  return [
+    { url: `${base}/`, lastModified: new Date() },
+    { url: `${base}/about`, lastModified: new Date() },
+    { url: `${base}/base64`, lastModified: new Date() },
+    { url: `${base}/case-converter`, lastModified: new Date() },
+    { url: `${base}/cookies`, lastModified: new Date() },
+    { url: `${base}/diff`, lastModified: new Date() },
+    { url: `${base}/format`, lastModified: new Date() },
+    { url: `${base}/image-converter`, lastModified: new Date() },
+    { url: `${base}/pdf`, lastModified: new Date() },
+    { url: `${base}/privacy`, lastModified: new Date() },
+    { url: `${base}/qr`, lastModified: new Date() },
+    { url: `${base}/random`, lastModified: new Date() },
+    { url: `${base}/terms`, lastModified: new Date() },
+  ];
+}


### PR DESCRIPTION
## Summary
- expand metadata for QR and Diff pages with canonical URLs, keywords, and social tags
- add dynamic sitemap.xml and robots.txt generators

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a93dae208832984ffe38829222f8f