### PR TITLE
chore: emphasise password generator and pdf seo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,8 +35,6 @@
 /* ===== Base ===== */
 html,body{ height:100%; background:hsl(var(--bg)); color:hsl(var(--text));
   -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale; }
-:root{ --font-sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;
-       --font-mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
 body{ font-family:var(--font-sans); }
 code,pre{ font-family:var(--font-mono); }
 *,*::before,*::after{ box-sizing:border-box; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,26 @@
-/* eslint-disable @next/next/no-img-element */
 import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 
 import ToolMenuWrapper from "@/components/ToolMenuWrapper";
 import ThemeToggle from "@/components/ThemeToggle";
 import ConsentBanner from "@/components/ConsentBanner";
 
-import { Poppins } from "next/font/google";
+import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 
-const poppins = Poppins({
-  weight: ["600"], // semi-bold
+const ibmPlexSans = IBM_Plex_Sans({
+  weight: ["400", "500", "600"],
   subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  weight: ["400", "600"],
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap",
 });
 
 
@@ -68,6 +77,14 @@ const jsonLd = {
     "Quick, private web tools that run locally in your browser.",
 };
 
+const jsonLdOrg = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Utilixy",
+  url: "https://utilixy.com",
+  logo: "https://utilixy.com/icons/icon-512.png",
+};
+
 
 export default function RootLayout({
   children,
@@ -75,25 +92,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${ibmPlexSans.variable} ${jetBrainsMono.variable}`}
+    >
       <head>
         {/* Ensure theme class is set before paint */}
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
 
-        {/* Fonts */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin=""
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
-          rel="stylesheet"
-        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdOrg) }}
         />
       </head>
 
@@ -124,7 +138,15 @@ export default function RootLayout({
         md:ml-4 lg:ml-6
       "
     >
-      <img src="/utilixy-nav.svg" alt="" aria-hidden="true" className="h-11 w-auto md:h-14" />
+      <Image
+        src="/utilixy-nav.svg"
+        alt=""
+        aria-hidden="true"
+        width={500}
+        height={500}
+        priority
+        className="h-11 w-auto md:h-14"
+      />
       <span className="text-[20px] md:text-[24px] tracking-tight font-semibold">Utilixy</span>
     </Link>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,10 +17,10 @@ export const metadata: Metadata = {
 
 const tools = [
   { href: "/pdf", title: "PDF Studio", desc: "Reorder, rotate, merge, split, numbers, watermark, extract, redact — locally." },
+  { href: "/random", title: "Password Generator", desc: "Strong passwords, UUIDs, colors, lorem, slugs." },
   { href: "/qr", title: "QR & Wi‑Fi", desc: "Create QR codes. Export PNG/SVG." },
   { href: "/image-converter", title: "Image Converter", desc: "HEIC → JPG/PNG/WebP. Local, private." },
   { href: "/format", title: "JSON / YAML / XML", desc: "Format, validate and convert." },
-  { href: "/random", title: "Random & Passwords", desc: "UUIDs, passwords, colors, lorem, slugs." },
   { href: "/case-converter", title: "Case Converter", desc: "Title, sentence, snake, kebab, camel, pascal." },
   { href: "/base64", title: "Base64", desc: "Encode or decode text and files." },
   { href: "/diff", title: "Text Diff", desc: "Compare two texts and see changes." },
@@ -80,7 +80,7 @@ export default function HomePage() {
                 { href: "/qr", label: "QR & Wi‑Fi" },
                 { href: "/image-converter", label: "Image converter" },
                 { href: "/format", label: "JSON/YAML/XML" },
-                { href: "/random", label: "Passwords & random" },
+                { href: "/random", label: "Password generator" },
               ].map((x) => (
                 <Link key={x.href} href={x.href} className="inline-flex items-center gap-2 rounded-full border border-line px-3 py-1 hover:bg-[hsl(var(--bg))/0.6] no-underline">
                   <span>{x.label}</span>

--- a/app/pdf/page.tsx
+++ b/app/pdf/page.tsx
@@ -6,16 +6,34 @@ export const metadata: Metadata = {
   title: "PDF Studio — Utilixy",
   description:
     "Reorder, rotate, split, merge, watermark, page numbers, extract text, images↔PDF, redaction and more — fully client-side.",
+  alternates: { canonical: "/pdf" },
 };
 
 export default function Page() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "PDF Studio",
+    applicationCategory: "UtilitiesApplication",
+    operatingSystem: "Web",
+    url: "https://utilixy.com/pdf",
+    description:
+      "Reorder, rotate, split, merge, watermark, page numbers, extract text, images↔PDF, redaction and more — fully client-side.",
+  };
+
   return (
-    <ToolLayout
-      title="PDF Studio"
-      description="Reorder, rotate, split, merge, watermark, page numbers, extract text, images↔PDF, redaction and more — all locally in your browser."
-      align="center"
-    >
-      <Client />
-    </ToolLayout>
+    <>
+      <ToolLayout
+        title="PDF Studio"
+        description="Reorder, rotate, split, merge, watermark, page numbers, extract text, images↔PDF, redaction and more — all locally in your browser."
+        align="center"
+      >
+        <Client />
+      </ToolLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
   );
 }

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -1,19 +1,24 @@
+import Link from "next/link";
 import ToolLayout from "@/components/ToolLayout";
 import Client from "./Client";
 
 export const metadata = {
-  title: "Random Generators — Utilixy",
+  title: "Password Generator & Random Tools — Utilixy",
   description:
-    "Passwords, UUIDs, colors, slugs, and lorem ipsum. Everything runs locally in your browser.",
+    "Generate strong passwords, UUIDs, colors, slugs and lorem ipsum locally in your browser.",
+  alternates: { canonical: "/random" },
 };
 
 export default function Page() {
   return (
     <ToolLayout
-      title="Random Data Generators"
-      description="Pick a generator, tweak options, and produce many results at once. Everything runs locally."
+      title="Password Generator & Random Tools"
+      description="Create strong passwords plus UUIDs, colors, slugs and lorem ipsum. Everything runs locally."
     >
       <Client />
+      <p className="mt-4 text-sm text-muted">
+        Need to work with PDFs? Try our <Link href="/pdf">PDF Studio</Link>.
+      </p>
     </ToolLayout>
   );
 }


### PR DESCRIPTION
## Summary
- replace external font links with next/font and add org JSON-LD
- emphasise password generator and pdf studio pages with canonical metadata and internal links
- add SoftwareApplication schema for PDF Studio

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a955fd418832987df046edcb6643d