### PR TITLE
Enable analytics and ad storage by default

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -115,10 +115,10 @@ export default function RootLayout({
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('consent', 'default', {
-                ad_user_data: 'denied',
-                ad_personalization: 'denied',
-                ad_storage: 'denied',
-                analytics_storage: 'denied'
+                ad_user_data: 'granted',
+                ad_personalization: 'granted',
+                ad_storage: 'granted',
+                analytics_storage: 'granted'
               });
             `,
           }}


### PR DESCRIPTION
## Summary
- Default Consent Mode settings now grant Google Analytics and advertising storage so tracking runs immediately.

## Testing
- ⚠️ `npm test` – no tests found, so none were run


------
https://chatgpt.com/codex/tasks/task_e_68a1f8097dec83299fa3885182949468