### PR TITLE
fix: align rotated watermark text

### DIFF
--- a/app/pdf/Client.tsx
+++ b/app/pdf/Client.tsx
@@ -943,7 +943,7 @@ function ToolWatermark() {
       }
 
       const tw = font.widthOfTextAtSize(content, size);
-      const th = font.heightAtSize(size);
+      const th = font.heightAtSize(size, { descender: false });
       const rgb01 = hexToRgb01(color);
 
       let originX = x;
@@ -3934,7 +3934,7 @@ pages.forEach((p, idx) => {
   }
 
   const w = font.widthOfTextAtSize(content, size);
-  const h = font.heightAtSize(size);
+  const h = font.heightAtSize(size, { descender: false });
   let originX = x;
   let originY = y;
   let rotateOpt = undefined;


### PR DESCRIPTION
## Summary
- ensure PDF watermarks center correctly by ignoring descenders when measuring font height

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a399966840832995a9db26fee41529