### PR TITLE
feat: add subtle page animations

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import ToolMenuWrapper from "@/components/ToolMenuWrapper";
 import ThemeToggle from "@/components/ThemeToggle";
 import FooterMultiplex from "@/components/ads/FooterMultiplex";
 import { Suspense } from "react";
+import AnimatedMain from "@/components/AnimatedMain";
 
 import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 
@@ -224,9 +225,9 @@ export default function RootLayout({
           <ToolMenuWrapper />
 
           {/* Main content */}
-          <main className="mx-auto container-wrap px-4 py-8 flex-1">
+          <AnimatedMain className="mx-auto container-wrap px-4 py-8 flex-1">
             {children}
-          </main>
+          </AnimatedMain>
 
           {/* Multiplex above footer on tool pages */}
           <FooterMultiplex />

--- a/components/AnimatedMain.tsx
+++ b/components/AnimatedMain.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function AnimatedMain({ children, className }: Props) {
+  return (
+    <motion.main
+      className={className}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+    >
+      {children}
+    </motion.main>
+  );
+}

--- a/components/ToolLayout.tsx
+++ b/components/ToolLayout.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 // components/ToolLayout.tsx
 import React, { ReactElement, ReactNode } from "react";
 import ShareButton from "./ShareButton";
+import { motion } from "framer-motion";
 
 /**
  * ToolLayout
@@ -34,7 +37,12 @@ export default function ToolLayout({
   const center = align === "center";
 
   return (
-    <section className="w-full">
+    <motion.section
+      className="w-full"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
       {/* Header: same width as content */}
       <div className="mx-auto w-full max-w-7xl px-4 md:px-6 lg:px-8">
         <div
@@ -61,6 +69,6 @@ export default function ToolLayout({
       <div className="mx-auto w-full max-w-7xl px-4 md:px-6 lg:px-8 mt-6">
         <div className="tool-panels">{items}</div>
       </div>
-    </section>
+    </motion.section>
   );
 }


### PR DESCRIPTION
## Summary
- add `AnimatedMain` component with framer-motion
- fade in main content site-wide and tool layout

## Testing
- `npm test` (fails: No tests found)
- `npx tsc --noEmit`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a3c6579e488329a906f48bb5bf6457