### PR TITLE
Improve dropdown readability and tool headings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -165,6 +165,14 @@ a{ text-underline-offset:3px; }
 .theme-dark .input{ border-color:hsl(var(--line)); }
 .input:focus-visible{ border-color:hsl(var(--ring)); box-shadow:0 0 0 3px hsl(var(--ring) / .25); }
 
+/* Make file inputs stand out for uploads */
+.input[type="file"]{
+  border-width:2px;
+  border-color:hsl(var(--ring));
+  background-color:hsl(var(--ring) / .05);
+  cursor:pointer;
+}
+
 /* Small inline input */
 .input-sm{
   width: 80px;
@@ -851,7 +859,8 @@ main:has(#seo-content) .tool-panels{
   /* Light theme */
   --panel-rgb: 255 255 255;      /* neutral, just blur */
   --panel-border-rgb: 196 199 204;
-  --panel-alpha: 0.4;
+  /* Increase opacity for clearer text on light theme */
+  --panel-alpha: 0.9;
 }
 /* If you toggle via .theme-dark (your ThemeToggle does), map here */
 .theme-dark {
@@ -879,7 +888,7 @@ main:has(#seo-content) .tool-panels{
   backdrop-filter: blur(36px) saturate(160%);
 
   border: 1px solid rgb(var(--panel-border-rgb) / 0.60);
-  box-shadow: 0 12px 36px rgb(0 0 0 / 0.35);
+  box-shadow: 0 12px 36px rgb(0 0 0 / 0.12);
   background-clip: padding-box; /* sharper edge on Safari */
   will-change: opacity, transform, backdrop-filter;
 }

--- a/app/image-converter/Client.tsx
+++ b/app/image-converter/Client.tsx
@@ -94,8 +94,8 @@ function DropZoneInline({
         className={
           "flex items-center justify-center rounded-lg border-2 border-dashed px-4 py-10 transition " +
           (drag
-            ? "border-blue-500 bg-blue-500/10"
-            : "border-line hover:bg-card")
+            ? "border-[#2B67F3] bg-[#2B67F3]/10"
+            : "border-[#2B67F3] hover:bg-[#2B67F3]/5")
         }
         aria-label="Drop images here or click to browse"
       >
@@ -901,7 +901,7 @@ export default function Client() {
             {/* Left: preview + thumbs (unchanged) */}
             <div className="order-2 lg:order-1">
               {activeLabel && (
-                <h2 className="text-base font-semibold mb-1">{activeLabel}</h2>
+                <h2 className="text-2xl font-bold mb-4 text-center text-[#2B67F3]">{activeLabel}</h2>
               )}
               <h3 className="text-sm font-medium mb-2">Live Preview</h3>
 

--- a/app/pdf/Client.tsx
+++ b/app/pdf/Client.tsx
@@ -607,7 +607,7 @@ export default function PDFStudio() {
         <main className="grid gap-6">
           <div>
             {activeLabel && (
-              <h2 className="text-base font-semibold mb-1">{activeLabel}</h2>
+              <h2 className="text-2xl font-bold mb-4 text-center text-[#2B67F3]">{activeLabel}</h2>
             )}
             {tool === "reorder" && <ToolReorderUX />}
             {tool === "rotate" && <ToolRotateUX />}

--- a/components/DesktopToolsNav.tsx
+++ b/components/DesktopToolsNav.tsx
@@ -179,7 +179,7 @@ export default function DesktopToolsNav() {
           <Link
             href="/pdf"
             role="menuitem"
-            className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white"
+            className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white"
             onClick={() => setPdfOpen(false)}
           >
             PDF Home
@@ -189,7 +189,7 @@ export default function DesktopToolsNav() {
               key={t.key}
               href={`/pdf?tool=${encodeURIComponent(t.key)}`}
               role="menuitem"
-              className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white"
+              className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white"
               onClick={() => setPdfOpen(false)}
             >
               {t.label}
@@ -238,7 +238,7 @@ export default function DesktopToolsNav() {
           <Link
             href="/image-converter"
             role="menuitem"
-            className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white"
+            className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white"
             onClick={() => setImageOpen(false)}
           >
             Image Home
@@ -248,7 +248,7 @@ export default function DesktopToolsNav() {
               key={t.key}
               href={`/image-converter?tool=${encodeURIComponent(t.key)}`}
               role="menuitem"
-              className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white"
+              className="block w-full whitespace-nowrap px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white"
               onClick={() => setImageOpen(false)}
             >
               {t.label}
@@ -299,16 +299,16 @@ export default function DesktopToolsNav() {
             "transition ease-out duration-150",
           ].join(" ")}
         >
-          <Link href="/case-converter" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
+          <Link href="/case-converter" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
             Case
           </Link>
-          <Link href="/base64" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
+          <Link href="/base64" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
             Base64
           </Link>
-          <Link href="/diff" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
+          <Link href="/diff" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
             Diff
           </Link>
-          <Link href="/regex" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
+          <Link href="/regex" role="menuitem" className="px-3 py-2 rounded-lg text-base font-semibold text-[#2B67F3] hover:bg-[#2B67F3] hover:text-white" onClick={() => setMoreOpen(false)}>
             Regex
           </Link>
         </div>

--- a/components/ImageConverter.tsx
+++ b/components/ImageConverter.tsx
@@ -79,8 +79,8 @@ export default function ImageConverter({
   return (
     <div className="space-y-6">
       <div className="card">
-        <h1 className="text-xl font-semibold mb-3">{title}</h1>
-        <p className="text-neutral-400 mb-4">{description}</p>
+        <h1 className="text-2xl md:text-3xl font-bold text-center text-[#2B67F3] mb-4">{title}</h1>
+        <p className="text-neutral-400 text-center mb-4">{description}</p>
 
         <div className="grid sm:grid-cols-2 gap-4">
           <div>


### PR DESCRIPTION
## Summary
- Brighten file upload inputs and tool drop zones
- Lighten navbar dropdowns and use brand blue text
- Center and enlarge tool headings for PDF and Image pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3cbc932d88329ba4f6747bb1085cc